### PR TITLE
Update Template Dockerfile Trailing Slash for Golang COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 COPY src/go.mod src/go.sum ./
 RUN go mod download
 # COPY src/ .
-COPY src/*.go .
+COPY src/*.go ./
 # COPY src/frontend/dist frontend/dist
 COPY src/config.toml .
 COPY --from=frontend-builder /app/dist frontend/dist


### PR DESCRIPTION
When building the following error will happen: 

Step 10/22 : COPY src/*.go .
When using COPY with more than one source file, the destination must be a directory and end with a / ERROR: Service 'app' failed to build : Build failed

The error is self explanatory and the update is to specify the directory with a trailing / 

You can then use your compose file with a `--no-cache` flag and it should pull the correct config when referencing a Dockerfile based off this. 

`docker-compose -f docker-compose.prod.yml build --no-cache`